### PR TITLE
security: add SECURITY.md vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+**PLEASE DON'T DISCLOSE SECURITY-RELATED ISSUES PUBLICLY, [SEE BELOW](#reporting-a-vulnerability).**
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately using one of the following channels:
+
+1. **GitHub Private Vulnerability Reporting** (preferred) — go to the repository's **Security** tab and click **"Report a vulnerability"**. This creates a private advisory visible only to maintainers and provides a structured workflow for triage, fix coordination, and CVE assignment.
+
+2. **Email** — send the details to security at **security@jelou.ai**.
+
+All security vulnerabilities will be promptly addressed.


### PR DESCRIPTION
## Summary
- Adds `SECURITY.md` with a private vulnerability disclosure policy
- Directs security researchers to GitHub Private Vulnerability Reporting (preferred) or `security@jelou.ai`
- Resolves the Vanta compliance check "Repositories have security policy"

## Test plan
- [ ] Verify `SECURITY.md` appears in the repository root
- [ ] Confirm the Security tab shows the disclosure policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Security policy established providing guidelines for privately reporting vulnerabilities. Users can submit security concerns through GitHub's private vulnerability reporting feature or email. All reported issues will receive prompt attention and remediation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JelouLatam/Widget-SDK-Android/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->